### PR TITLE
Updating react-day-picker version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,9 @@
     "lucide-react": "^0.454.0",
     "next": "14.2.16",
     "next-themes": "latest",
+    "qrcode": "^1.5.4",
     "react": "^18",
-    "react-day-picker": "8.10.1",
+    "react-day-picker": "^9.0.0",
     "react-dom": "^18",
     "react-hook-form": "^7.54.1",
     "react-resizable-panels": "^2.1.7",
@@ -65,6 +66,7 @@
   },
   "devDependencies": {
     "@types/node": "^22",
+    "@types/qrcode": "^1.5.5",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "next-themes": "latest",
     "qrcode": "^1.5.4",
     "react": "^18",
-    "react-day-picker": "^9.0.0",
+    "react-day-picker": "8.10.1",
     "react-dom": "^18",
     "react-hook-form": "^7.54.1",
     "react-resizable-panels": "^2.1.7",


### PR DESCRIPTION
Updated package.json to avoid npm errors like the below issue since react-day-picker v8.10.1 is compatible with **date-fns v2.28.0 -> v^3.0.0**. **date-fns v.4.1.0** is not compatible with react-day-picker@8.10.1. Locally, using react-day-picker@8.10.1 doesn't work locally when I do **npm i** or **npm i qrcode**, but compiles on netlify

The commit here at https://github.com/extinctsion/quickkURL/pull/6/commits/9404d25a46c13d24d946a609b9cf5983863c3fa4 works locally when I run the npm commands to install required packages, but fails on netlify.

<img width="711" alt="image" src="https://github.com/user-attachments/assets/87fe3dd3-cbb1-45cd-a633-8cceb42f7bfa" />


